### PR TITLE
Allow for recursive search of features

### DIFF
--- a/featureFileSplitter.js
+++ b/featureFileSplitter.js
@@ -37,7 +37,7 @@ var featureFileSplitter = function featureFileSplitter() {
 
             var filePaths = [];
             if (options.ff == undefined) {
-                filePaths = glob.sync(options.sourceSpecDirectory + "/*.feature");
+                filePaths = glob.sync(options.sourceSpecDirectory + "/**/*.feature");
             } else {
                 var featureFile = options.sourceSpecDirectory + "/" + options.ff + ".feature";
                 filePaths.push(featureFile);


### PR DESCRIPTION
Allow for recursive search of features in the `sourceSpecDirectory` specified by using a globbing pattern. In a directory structure like so:

```
/features
--> featureC.feature
--> folder1
    --> folder2
       --> featureA.feature
--> folder3
   --> featureB.feature
```

it performs setup for all the features instead of just `featureC.feature`.

The same could possible be done for the `ff` option:
```js
var featureFile = options.sourceSpecDirectory + "**/" + options.ff + ".feature";
```

Edit: `sourceSpecDirectory` can be specified as a globing pattern so there is no need  for this change.