### PR TITLE
Fix crash due to node-emoji dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "glob": "7.1.3",
     "lodash": "4.17.15",
     "uniqid": "5.0.3",
-    "node-dir": "0.1.17"
+    "node-dir": "0.1.17",
+    "node-emoji": "^1.10.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
-    "chalk": "^2.4.2",
-    "node-emoji": "^1.10.0"
+    "chalk": "^2.4.2"
   }
 }


### PR DESCRIPTION
This file uses node-emoji:
https://github.com/SimitTomar/wdio-cucumber-parallel-execution/blob/8435e223c9ac5ae5cf76e1595bb67059e83df66c/performSetup.js#L6

Yet it is declared as a dev depedency:
https://github.com/SimitTomar/wdio-cucumber-parallel-execution/blob/8435e223c9ac5ae5cf76e1595bb67059e83df66c/package.json#L36-L41
It leads to a nasty crash:
```javascript
Error: Cannot find module 'node-emoji'
Require stack:
- wdio-cucumber-parallel-execution/performSetup.js
- wdio-cucumber-parallel-execution/index.js
- @wdio/config/build/lib/ConfigParser.js
- @wdio/config/build/index.js
- @wdio/cli/build/launcher.js
- @wdio/cli/build/index.js
- @wdio/cli/bin/wdio.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:982:15)
    at Function.Module._load (internal/modules/cjs/loader.js:864:27)
    at Module.require (internal/modules/cjs/loader.js:1044:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (wdio-cucumber-parallel-execution/performSetup.js:6:13)
    at Module._compile (internal/modules/cjs/loader.js:1158:30)
    at Module._compile (pirates/lib/index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
    at Object.newLoader [as .js] (pirates/lib/index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:1002:32)
    at Function.Module._load (internal/modules/cjs/loader.js:901:14)
    at Module.require (internal/modules/cjs/loader.js:1044:19)
    at require (internal/modules/cjs/helpers.js:77:18)
    at Object.<anonymous> (wdio-cucumber-parallel-execution/index.js:4:20)
    at Module._compile (internal/modules/cjs/loader.js:1158:30)
    at Module._compile (pirates/lib/index.js:99:24)
```